### PR TITLE
[#14] Add Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+<!--- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!--- Steps to reproduce the behavior -->
+
+**Expected behavior**
+<!--- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!--- If applicable, add screenshots to help explain your problem. -->
+
+**Potential fix**
+<!--- If you are aware of a potential fix, please share the details.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**What feature are your requesting?**
+<!--- A clear and concise description of the request -->
+
+**What benefits do you foresee from the feature you are requesting?**
+<!--- A clear and concise description of what you want to happen. -->
+
+**Potential solution/ideas?**
+<!--- If you happen to have some ideas on how the implementation should be, feel free to jot down the details here. -->
+
+**Additional context**
+<!--- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
- This PR fixes #14 

- This PR adds two templates : features & bugs. Having a standard template reduces back and forth on new issues, because all the mandatory questions are asked when someone opens a new issue

- To feel how this will work -
-- goto https://github.com/Dee-Pac/PPExtensions/issues
-- click "New Issue"  OR go here : https://github.com/Dee-Pac/PPExtensions/issues/new/choose 